### PR TITLE
Autosync

### DIFF
--- a/src/components/editor/components/text-preview-column/index.tsx
+++ b/src/components/editor/components/text-preview-column/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
-import { ScrollVals } from "../text-preview";
+
+import { ScrollHeights } from "../text-preview";
 import { TextPreviewMd } from "../text-preview-md";
 import styles from "./text-preview-column.module.css";
 
@@ -7,7 +8,7 @@ interface ITextPreviewColumnProps {
   source: string;
   isFirstCol: boolean;
   isLastCol: boolean;
-  setScrollVals: (scrollVals: ScrollVals) => void;
+  setScrollHeights: (scrollHeights: ScrollHeights) => void;
   scrollToCoord: number;
   lastScrollToCoord: number;
 }
@@ -16,7 +17,7 @@ export const TextPreviewColumn = ({
   source,
   isFirstCol,
   isLastCol,
-  setScrollVals,
+  setScrollHeights,
   scrollToCoord,
   lastScrollToCoord,
 }: ITextPreviewColumnProps): JSX.Element => {
@@ -34,12 +35,12 @@ export const TextPreviewColumn = ({
       !!scrollContainer &&
       !!previewContainer
     ) {
-      setScrollVals({
+      setScrollHeights({
         containerHeight: scrollContainer.offsetHeight,
-        contentHeight: previewContainer.offsetHeight,
+        previewHeight: previewContainer.offsetHeight,
       });
     }
-  }, [isFirstCol, previewRendered, setScrollVals, lastScrollToCoord]);
+  }, [isFirstCol, previewRendered, setScrollHeights, lastScrollToCoord]);
 
   // scroll to the correct place after additional columns are added
   useEffect(() => {

--- a/src/components/editor/components/text-preview-column/index.tsx
+++ b/src/components/editor/components/text-preview-column/index.tsx
@@ -22,7 +22,7 @@ export const TextPreviewColumn = ({
   setScrollHeights,
   scrollToCoord,
 }: ITextPreviewColumnProps): JSX.Element => {
-  const [previewRendered, setPreviewRendered] = useState(false);
+  const [_, setPreviewRendered] = useState(false);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const previewContainerRef = useRef<HTMLDivElement>(null);
 
@@ -31,7 +31,6 @@ export const TextPreviewColumn = ({
       const height = !!entries[0] ? entries[0].contentRect.height : 0;
       if (height !== lastScrollContainerHeight) {
         lastScrollContainerHeight = height;
-        console.log(`:::s-HEIGHT::: `, height);
         setScrollHeights((prevScrollHeights) => ({
           ...prevScrollHeights,
           containerHeight: height,
@@ -42,7 +41,6 @@ export const TextPreviewColumn = ({
       const height = !!entries[0] ? entries[0].contentRect.height : 0;
       if (height !== lastPreviewContainerHeight) {
         lastPreviewContainerHeight = height;
-        console.log(`:::p-HEIGHT::: `, height);
         setScrollHeights((prevScrollHeights) => ({
           ...prevScrollHeights,
           previewHeight: height,
@@ -52,37 +50,20 @@ export const TextPreviewColumn = ({
 
     const scrollContainer = scrollContainerRef.current;
     const previewContainer = previewContainerRef.current;
-    if (
-      isFirstCol &&
-      // previewRendered &&
-      !!scrollContainer &&
-      !!previewContainer
-    ) {
+    if (isFirstCol && !!scrollContainer && !!previewContainer) {
       scrollContainerObserver.observe(scrollContainer);
       previewContainerObserver.observe(previewContainer);
+
+      return () => {
+        scrollContainerObserver.unobserve(scrollContainer);
+        previewContainerObserver.unobserve(previewContainer);
+      };
     }
   }, [isFirstCol, setScrollHeights]);
 
-  // calculate scroll height values and sent back to parent comp
-  // useEffect(() => {
-  //   const scrollContainer = scrollContainerRef.current;
-  //   const previewContainer = previewContainerRef.current;
-  //   if (
-  //     isFirstCol &&
-  //     previewRendered &&
-  //     !!scrollContainer &&
-  //     !!previewContainer
-  //   ) {
-  //     setScrollHeights({
-  //       containerHeight: scrollContainer.offsetHeight,
-  //       previewHeight: previewContainer.offsetHeight,
-  //     });
-  //   }
-  // }, [isFirstCol, previewRendered, setScrollHeights, lastScrollToCoord]);
-
   // scroll to the correct place after additional columns are added
   const scrollContainer = scrollContainerRef.current;
-  if (previewRendered && !!scrollContainer) {
+  if (!!scrollContainer) {
     scrollContainer.scrollTo({ top: scrollToCoord });
   }
 

--- a/src/components/editor/components/text-preview/index.tsx
+++ b/src/components/editor/components/text-preview/index.tsx
@@ -20,7 +20,6 @@ export const TextPreview = ({
     containerHeight: 0,
     previewHeight: 0,
   });
-  console.log(`:::SCROLLHEIGHTS::: `, scrollHeights);
   const SCROLL_OVERLAP = 64;
   const INIT_SCROLL_COORD = 0;
 
@@ -39,7 +38,6 @@ export const TextPreview = ({
       }
 
       newScrollToCoords.length > 1 && newScrollToCoords.pop(); // last one will be more than previewHeight by nature of while loop
-      // setScrollToCoords([0]);
       setScrollToCoords(newScrollToCoords);
     }
   }, [scrollHeights, resync]);

--- a/src/components/editor/components/text-preview/index.tsx
+++ b/src/components/editor/components/text-preview/index.tsx
@@ -2,9 +2,9 @@ import { useEffect, useState } from "react";
 import { TextPreviewColumn } from "../text-preview-column";
 import styles from "./text-preview.module.css";
 
-export interface ScrollVals {
+export interface ScrollHeights {
   containerHeight: number;
-  contentHeight: number;
+  previewHeight: number;
 }
 
 interface ITextPreviewProps {
@@ -16,9 +16,9 @@ export const TextPreview = ({
   source,
   resync,
 }: ITextPreviewProps): JSX.Element => {
-  const [scrollVals, setScrollVals] = useState<ScrollVals>({
+  const [scrollHeights, setScrollHeights] = useState<ScrollHeights>({
     containerHeight: 0,
-    contentHeight: 0,
+    previewHeight: 0,
   });
   const SCROLL_OVERLAP = 64;
   const INIT_SCROLL_COORD = 0;
@@ -26,23 +26,22 @@ export const TextPreview = ({
   const [scrollToCords, setScrollToCoords] = useState([0]);
 
   useEffect(() => {
-    if (Object.values(scrollVals).every((val) => val > 0)) {
+    if (Object.values(scrollHeights).every((val) => val > 0)) {
       const newScrollToCoords: number[] = [INIT_SCROLL_COORD];
-      while (
-        (newScrollToCoords.at(-1) ?? INIT_SCROLL_COORD) <
-        scrollVals.contentHeight
-      ) {
-        const scrollToCoord =
-          (newScrollToCoords.at(-1) ?? INIT_SCROLL_COORD) +
-          scrollVals.containerHeight -
-          SCROLL_OVERLAP;
-        newScrollToCoords.push(scrollToCoord);
+      const getLastScrollCoord = () =>
+        newScrollToCoords.at(-1) ?? INIT_SCROLL_COORD;
+
+      while (getLastScrollCoord() < scrollHeights.previewHeight) {
+        const nextScrollToCoord =
+          getLastScrollCoord() + scrollHeights.containerHeight - SCROLL_OVERLAP;
+        newScrollToCoords.push(nextScrollToCoord);
       }
 
-      newScrollToCoords.pop(); // last one will be more than contentHeight by nature of while loop
+      newScrollToCoords.length > 1 && newScrollToCoords.pop(); // last one will be more than previewHeight by nature of while loop
+      setScrollToCoords([0]);
       setScrollToCoords(newScrollToCoords);
     }
-  }, [scrollVals]);
+  }, [scrollHeights, resync]);
 
   useEffect(() => setScrollToCoords([0]), [resync]);
 
@@ -50,11 +49,11 @@ export const TextPreview = ({
     <div className={styles.comp}>
       {scrollToCords.map((coord, idx) => (
         <TextPreviewColumn
-          key={idx}
+          key={coord}
           source={source}
           isFirstCol={idx === 0}
           isLastCol={idx === scrollToCords.length - 1}
-          setScrollVals={setScrollVals}
+          setScrollHeights={setScrollHeights}
           scrollToCoord={coord}
           lastScrollToCoord={scrollToCords.at(-1) ?? 0} // important for rerendering appropriately
         />

--- a/src/components/editor/components/text-preview/index.tsx
+++ b/src/components/editor/components/text-preview/index.tsx
@@ -20,6 +20,7 @@ export const TextPreview = ({
     containerHeight: 0,
     previewHeight: 0,
   });
+  console.log(`:::SCROLLHEIGHTS::: `, scrollHeights);
   const SCROLL_OVERLAP = 64;
   const INIT_SCROLL_COORD = 0;
 
@@ -38,7 +39,7 @@ export const TextPreview = ({
       }
 
       newScrollToCoords.length > 1 && newScrollToCoords.pop(); // last one will be more than previewHeight by nature of while loop
-      setScrollToCoords([0]);
+      // setScrollToCoords([0]);
       setScrollToCoords(newScrollToCoords);
     }
   }, [scrollHeights, resync]);
@@ -55,7 +56,6 @@ export const TextPreview = ({
           isLastCol={idx === scrollToCords.length - 1}
           setScrollHeights={setScrollHeights}
           scrollToCoord={coord}
-          lastScrollToCoord={scrollToCords.at(-1) ?? 0} // important for rerendering appropriately
         />
       ))}
     </div>

--- a/src/components/editor/hooks/use-auto-sync.tsx
+++ b/src/components/editor/hooks/use-auto-sync.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react";
+
+let autoSyncReady = false;
+
+let resizeTimestamp = 0;
+let resizeJustStarted = true;
+
+export const useAutoSync = () => {
+  const [autoSync, _setAutoSync] = useState<{} | null>(null);
+
+  const triggerAutoSync = () => {
+    if (autoSyncReady) _setAutoSync({});
+    autoSyncReady = true;
+  };
+
+  const [needsSync, setNeedsSync] = useState({});
+
+  useEffect(() => {
+    const onResize = (e: UIEvent) => {
+      if (e.timeStamp - resizeTimestamp > 250) {
+        resizeTimestamp = e.timeStamp;
+
+        if (resizeJustStarted) {
+          resizeJustStarted = false;
+        } else {
+          setNeedsSync({});
+        }
+      }
+    };
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+
+  useEffect(() => {
+    const resyncTimeout = setTimeout(triggerAutoSync, 750);
+    return () => clearTimeout(resyncTimeout);
+  }, [needsSync]);
+
+  return autoSync;
+};

--- a/src/components/editor/hooks/use-auto-sync.tsx
+++ b/src/components/editor/hooks/use-auto-sync.tsx
@@ -1,9 +1,7 @@
 import { useEffect, useState } from "react";
 
 let autoSyncReady = false;
-
 let resizeTimestamp = 0;
-let resizeJustStarted = true;
 
 export const useAutoSync = () => {
   const [autoSync, _setAutoSync] = useState<{} | null>(null);
@@ -19,12 +17,7 @@ export const useAutoSync = () => {
     const onResize = (e: UIEvent) => {
       if (e.timeStamp - resizeTimestamp > 250) {
         resizeTimestamp = e.timeStamp;
-
-        if (resizeJustStarted) {
-          resizeJustStarted = false;
-        } else {
-          setNeedsSync({});
-        }
+        setNeedsSync({});
       }
     };
     window.addEventListener("resize", onResize);

--- a/src/components/editor/index.tsx
+++ b/src/components/editor/index.tsx
@@ -36,11 +36,6 @@ export const Editor = ({}): JSX.Element => {
       document.body.removeEventListener("keydown", listenForShortcuts);
   }, [toggleTextMode]);
 
-  // const autoSync = useAutoSync();
-  // useEffect(() => {
-  //   triggerSync();
-  // }, [autoSync]);
-
   return (
     <div className={styles.comp}>
       <div className={styles.controls}>

--- a/src/components/editor/index.tsx
+++ b/src/components/editor/index.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useState } from "react";
 import { TextEdit } from "./components/text-edit";
 import { TextPreview } from "./components/text-preview";
 import styles from "./editor.module.css";
-import { useAutoSync } from "./hooks/use-auto-sync";
 import { testMd } from "./test-md";
 import { testSong } from "./test-song";
 
@@ -37,10 +36,10 @@ export const Editor = ({}): JSX.Element => {
       document.body.removeEventListener("keydown", listenForShortcuts);
   }, [toggleTextMode]);
 
-  const autoSync = useAutoSync();
-  useEffect(() => {
-    triggerSync();
-  }, [autoSync]);
+  // const autoSync = useAutoSync();
+  // useEffect(() => {
+  //   triggerSync();
+  // }, [autoSync]);
 
   return (
     <div className={styles.comp}>

--- a/src/components/editor/index.tsx
+++ b/src/components/editor/index.tsx
@@ -2,15 +2,16 @@ import { useCallback, useEffect, useState } from "react";
 import { TextEdit } from "./components/text-edit";
 import { TextPreview } from "./components/text-preview";
 import styles from "./editor.module.css";
+import { useAutoSync } from "./hooks/use-auto-sync";
 import { testMd } from "./test-md";
 import { testSong } from "./test-song";
 
-interface IEditorProps {}
-
-export const Editor = ({}: IEditorProps): JSX.Element => {
+export const Editor = ({}): JSX.Element => {
   const [text, setText] = useState(testSong);
-  const [resync, _setResync] = useState({});
-  const triggerResync = () => _setResync({});
+  const [sync, _setSync] = useState({});
+  const triggerSync = () => {
+    _setSync({});
+  };
 
   enum TextMode {
     "edit",
@@ -35,20 +36,26 @@ export const Editor = ({}: IEditorProps): JSX.Element => {
     return () =>
       document.body.removeEventListener("keydown", listenForShortcuts);
   }, [toggleTextMode]);
+
+  const autoSync = useAutoSync();
+  useEffect(() => {
+    triggerSync();
+  }, [autoSync]);
+
   return (
     <div className={styles.comp}>
       <div className={styles.controls}>
         <div className={styles.controlGroup}>
           <button onClick={toggleTextMode}>Edit/Preview</button>
           {textMode === TextMode.preview && (
-            <button onClick={triggerResync}>Sync</button>
+            <button onClick={triggerSync}>Sync</button>
           )}
         </div>
         <div className={styles.controlGroup}>
           <button
             onClick={() => {
               setText(testSong);
-              triggerResync();
+              triggerSync();
             }}
           >
             Test Lyrics
@@ -56,7 +63,7 @@ export const Editor = ({}: IEditorProps): JSX.Element => {
           <button
             onClick={() => {
               setText(testMd);
-              triggerResync();
+              triggerSync();
             }}
           >
             Test Markdown
@@ -66,7 +73,7 @@ export const Editor = ({}: IEditorProps): JSX.Element => {
       {textMode === TextMode.edit ? (
         <TextEdit text={text} setText={setText} />
       ) : (
-        <TextPreview source={text} resync={resync} />
+        <TextPreview source={text} resync={sync} />
       )}
     </div>
   );


### PR DESCRIPTION
- added a hook for auto sync (ended up not using this, but kept for debouncing logic)
- rejiggered the column-building logic to use resize observers to calculate scroll and preview height, which killed some circular logic edgecases and enabled instant auto-syncing